### PR TITLE
reverting the use of mode managers

### DIFF
--- a/qmpy/analysis/nearest_neighbors.py
+++ b/qmpy/analysis/nearest_neighbors.py
@@ -106,7 +106,10 @@ def _heuristic(structure, limit=5, tol=2e-1):
         # map index back into the original cell
         inds %= structure.natoms
         site.neighbors = [ structure.sites[j] for j in inds ]
-        nns[site] = site.neighbors
+        ## nns[site] = site.neighbors
+        ## `qmpy.Site` objects that are not saved are not hashable, and hence
+        ## cannot be used as dictionary keys. Unit tests will fail.
+        nns[i] = site.neighbors
         for atom in site:
             atom.neighbors = []
             for n in site.neighbors:
@@ -142,5 +145,9 @@ def _voronoi(structure, limit=5, tol=1e-2):
             ind = [k for k in tess.ridge_points[j] if k != i ][0]
             # map the atom index back into the original cell. 
             atom.neighbors.append(atom)
-        nns[atom] = atom.neighbors
+        ## nns[atom] = atom.neighbors
+        ## `qmpy.Atom` objects that are not saved are not hashable, and hence
+        ## cannot be used as dictionary keys. Unit tests will fail.
+        nns[i] = atom.neighbors
     return nns
+

--- a/qmpy/analysis/symmetry/routines.py
+++ b/qmpy/analysis/symmetry/routines.py
@@ -103,7 +103,8 @@ def _cell_to_structure(cell, structure, rev_lookup):
         raise qmpy.StructureError('Input is not of type `qmpy.Structure`')
     structure.cell = cell[0]
     nsites = len(cell[1])
-    structure.set_nsites_manager(cell[1])
+    structure.set_nsites(nsites)
+    structure.site_coords = cell[1]
     site_comps = [rev_lookup[k] for k in cell[2]]
     structure.site_compositions = site_comps
 

--- a/qmpy/io/ase_mapper.py
+++ b/qmpy/io/ase_mapper.py
@@ -54,7 +54,8 @@ def atoms_to_structure(atoms):
     struct = Structure()
     struct.cell = atoms.get_cell()
     for a in atoms: 
-        atom = Atom.managerobject.create_atom(a.position)
+        atom = Atom()
+        atom.coord = a.position
         atom.symbol = a.symbol
         atom.magmom = a.magmom
         atom.direct = False

--- a/qmpy/io/cif.py
+++ b/qmpy/io/cif.py
@@ -63,7 +63,8 @@ def _get_b_factor(atom):
 
 def _get_atom(cba):
     """Convert a _atom loop to an Atom"""
-    atom = strx.Atom.managerobject.create_atom(_get_atom_coord(cba))
+    atom = strx.Atom()
+    atom.coord =_get_atom_coord(cba)
     atom.element_id = _get_element(cba)
     if atom.element_id == 'D' or atom.element_id == 'T':
         atom.element_id = 'H'

--- a/qmpy/io/poscar.py
+++ b/qmpy/io/poscar.py
@@ -197,15 +197,13 @@ def read(poscar, species=None):
     atoms = []
     inv = np.linalg.inv(cell).T
     for i in range(struct.natoms):
-        #atom = st.Atom.managerobject.create_atom()
-        #atom.element_id = atom_types[i]
+        atom = st.Atom()
+        atom.element_id = atom_types[i]
         if direct:
-            atomic_coord = [ float(v) for v in poscar.readline().split()[0:3] ]
+            atom.coord = [ float(v) for v in poscar.readline().split()[0:3] ]
         else:
             cart = [ float(v) for v in poscar.readline().split()[0:3] ]
-            atomic_coord = np.dot(inv, cart)
-        atom = st.Atom.managerobject.create_atom(coord=atomic_coord)
-        atom.element_id = atom_types[i]
+            atom.coord = np.dot(inv, cart)
         struct.add_atom(atom)
     struct.get_volume()
     struct.set_composition()

--- a/qmpy/materials/atom.py
+++ b/qmpy/materials/atom.py
@@ -28,15 +28,6 @@ class AtomError(qmpy.qmpyBaseError):
 class SiteError(qmpy.qmpyBaseError):
     pass
 
-
-# New in Django>1.8. Model instance has to be saved before they can be used as dict keys
-# The recommended method is to use a class manager: 
-# https://docs.djangoproject.com/en/2.2/ref/models/instances/
-class AtomManager(models.Manager):
-    def create_atom(self,coord):
-        site = self.create(coord=coord)
-        return site
-
 class Atom(models.Model):
     """
     Model for an Atom.
@@ -87,7 +78,6 @@ class Atom(models.Model):
     dist = None
     copy_of = None
 
-    managerobject = AtomManager()
     class Meta:
         app_label = 'qmpy'
         db_table = 'atoms'
@@ -252,7 +242,8 @@ class Atom(models.Model):
                     site.add_atom(self, tol=tol)
                     return site
 
-        s = Site.managerobject.create_site(self.coord)
+        s = Site()
+        s.coord = self.coord
         s.structure = self.structure
         s.atoms = [self]
         self.site = s
@@ -288,13 +279,6 @@ class Atom(models.Model):
         return dist < tol
 
 
-# New in Django>1.8. Model instance has to be saved before they can be used as dict keys
-# The recommended method is to use a class manager: 
-# https://docs.djangoproject.com/en/2.2/ref/models/instances/
-class SiteManager(models.Manager):
-    def create_site(self,coord):
-        site = self.create(coord=coord)
-        return site
 
 
 class Site(models.Model):
@@ -318,7 +302,7 @@ class Site(models.Model):
     x = models.FloatField()
     y = models.FloatField()
     z = models.FloatField()
-    managerobject = SiteManager()
+
     class Meta:
         app_label = 'qmpy'
         db_table = 'sites'

--- a/qmpy/materials/structure.py
+++ b/qmpy/materials/structure.py
@@ -1227,21 +1227,10 @@ class Structure(models.Model, object):
         self.atoms = [ Atom() for i in range(n) ]
         self._sites = None
 
-    def set_natoms_manager(self, coords):
-        """Sets self.atoms using atom manager - for Django >1.8 compatibility to be used as dict keys."""
-        self.atoms = [ Atom.managerobject.create_atom(coord) for coord in coords ]
-        self._sites = None
-
     def set_nsites(self, n):
         """Sets self.sites to n blank Sites."""
         self.sites = [ Site() for i in range(n) ]
         self._atoms = None
-
-    def set_nsites_manager(self, coords):
-        """Sets self.sites using site manager - for Django >1.8 compatibility to be used as dict keys."""
-        self.sites = [ Site.managerobject.create_site(coord) for coord in coords ]
-        self._atoms = None
-
 
     def make_conventional(self, in_place=True, tol=1e-3):
         """Uses spglib to convert to the conventional cell.

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "djangorestframework-filters == 0.11.1",
         "django-crispy-forms",
         "lark-parser",
-        "requests"
+        "requests",
+        "pygraphviz"
     ],
 )


### PR DESCRIPTION
To avoid error-prone automatic object saving by non-root users. It is relevant when someone accesses live oqmd in larue from outside of Larue or from a non-oqmd account in larue. For eg, qmpy will try to save all the atoms to the DB, even if someone is using qmpy just to open a poscar for small-scale analysis. This reversion of model managers is possible because @hegdevinayi changed the nearest_neighbors script to not use atom/site model objects as dictionary keys.