### PR TITLE
regex parsing improvement for Optimade

### DIFF
--- a/qmpy/utils/rest_query_parser.py
+++ b/qmpy/utils/rest_query_parser.py
@@ -47,7 +47,7 @@ def optimade_filter_conversion(filter_expr):
     filter_expr_out = filter_expr_out.replace('&', 'AND')
     filter_expr_out = filter_expr_out.replace('|', 'OR')
     # Convert 'elements=' into mutiple 'element=' filters
-    for els in re.findall('elements=[\S]*', filter_expr):
+    for els in re.findall('elements=[^-0-9\/]+', filter_expr):
         els_out = els.replace('elements=', '')
 
         els_lst = [' element='+e+' ' for e in els_out.split(',')]

--- a/qmpy/web/views/api/optimade_api.py
+++ b/qmpy/web/views/api/optimade_api.py
@@ -99,6 +99,8 @@ class OptimadeStructureList(generics.ListAPIView):
         filters = filters.replace('|', ' OR ')
         filters = filters.replace('~', ' NOT ')
         q = query_to_Q(filters)
+        if not q:
+            return [] 
         fes = fes.filter(q)
 
         return fes


### PR DESCRIPTION
the keyword `nelements` was being filtered in as `elements` while searching for the element set in the query. Solved now.