### PR TITLE
Update calculation.py

### DIFF
--- a/qmpy/analysis/vasp/calculation.py
+++ b/qmpy/analysis/vasp/calculation.py
@@ -247,7 +247,7 @@ class Calculation(models.Model):
         for h in self.hubbards:
             if not h:
                 continue
-            for a in self.input:
+            for a in self.output:
                 if ( h.element == a.element and
                         h.ox in [None, a.ox]):
                     hcomp[h] += 1


### PR DESCRIPTION
Change `hub_comp` to refer to `calculation.output` instead of `calculation.input`, to avoid issues caused by wrong input structures.

E.g. http://larue.northwestern.edu:4870/materials/entry/1072674. The formation energy (as of now) is erroneously calculated to be `-2.01 eV/atom` instead of the correct value of `-1.48 eV/atom`. This PR fixes that.