### PR TITLE
Hotfix/duplicated atoms

### DIFF
--- a/qmpy/analysis/vasp/calculation.py
+++ b/qmpy/analysis/vasp/calculation.py
@@ -1421,9 +1421,9 @@ class Calculation(models.Model):
         new = copy.deepcopy(self)
         new.id = None
         new.label = None
-        new.input = self.input
-        new.output = self.output
-        new.dos = self.dos
+        new.input = self.input.copy()
+        new.output = self.output.copy()
+        new.dos = copy.deepcopy(self.dos)
         return new
 
     def move(self, path):

--- a/qmpy/analysis/vasp/calculation.py
+++ b/qmpy/analysis/vasp/calculation.py
@@ -218,7 +218,7 @@ class Calculation(models.Model):
     def formation(self):
         fe_set = self.formationenergy_set.filter(fit__name='standard')
         if len(fe_set)==0:
-            return get_formation()
+            return self.get_formation()
         else:
             return fe_set[0]
 
@@ -1761,7 +1761,7 @@ class Calculation(models.Model):
         try:
             fe_set = self.formationenergy_set.filter(fit__name=reference)
             if len(fe_set)==0:
-                return get_formation(reference=reference).delta_e
+                return self.get_formation(reference=reference).delta_e
             else:
                 return fe_set[0].delta_e
         except AttributeError:

--- a/qmpy/analysis/vasp/calculation.py
+++ b/qmpy/analysis/vasp/calculation.py
@@ -1778,7 +1778,6 @@ class Calculation(models.Model):
             formation.entry = self.entry
             formation.calculation = self
             formation.stability = None
-            formation.save()
             return formation
         hub_mus = chem_pots[reference]["hubbards"]
         elt_mus = chem_pots[reference]["elements"]
@@ -1792,7 +1791,6 @@ class Calculation(models.Model):
         formation.entry = self.entry
         formation.calculation = self
         formation.stability = None
-        formation.save()
         return formation
 
     @staticmethod

--- a/qmpy/analysis/vasp/calculation.py
+++ b/qmpy/analysis/vasp/calculation.py
@@ -64,10 +64,10 @@ def vasp_format(key, value):
 class VaspError(Exception):
     """General problem with vasp calculation."""
 
+
 @add_meta_data("error")
 @add_meta_data("warning")
 @add_meta_data("Co_spin")
-
 class Calculation(models.Model):
     """
     Base class for storing a VASP calculation.
@@ -210,14 +210,13 @@ class Calculation(models.Model):
         self.meta_data.set(self.error_objects)
         super(Calculation, self).save(*args, **kwargs)
 
-
     # django caching
     _potentials = None
 
     @property
     def formation(self):
-        fe_set = self.formationenergy_set.filter(fit__name='standard')
-        if len(fe_set)==0:
+        fe_set = self.formationenergy_set.filter(fit__name="standard")
+        if len(fe_set) == 0:
             return self.get_formation()
         else:
             return fe_set[0]
@@ -554,7 +553,7 @@ class Calculation(models.Model):
     def get_outcar(self):
         """
         Sets the calculations outcar attribute to a list of lines from the
-        outcar. 
+        outcar.
 
         Examples::
 
@@ -564,7 +563,7 @@ class Calculation(models.Model):
             >>> calc.get_outcar()
             >>> len(calc.outcar)
             12345L
-        
+
         """
         if not self.outcar is None:
             return self.outcar
@@ -572,9 +571,11 @@ class Calculation(models.Model):
             return
         elif exists(self.path + "/OUTCAR"):
             try:
-                self.outcar = open(self.path + "/OUTCAR","r").readlines()
+                self.outcar = open(self.path + "/OUTCAR", "r").readlines()
             except UnicodeDecodeError:
-                self.outcar = open(self.path + "/OUTCAR","r",encoding='ISO-8859-1').readlines()
+                self.outcar = open(
+                    self.path + "/OUTCAR", "r", encoding="ISO-8859-1"
+                ).readlines()
         elif exists(self.path + "/OUTCAR.gz"):
             outcar = gzip.open(self.path + "/OUTCAR.gz", "rb").read().decode()
             self.outcar = outcar.splitlines()
@@ -613,7 +614,7 @@ class Calculation(models.Model):
             >>> calc = Calculation.read('calculation_path')
             >>> calc.read_energies()
             array([-12.415236, -12.416596, -12.416927])
-        
+
         """
         self.get_outcar()
         energies = []
@@ -643,7 +644,7 @@ class Calculation(models.Model):
     def read_elements(self):
         """
         Reads the elements of the atoms in the structure. Returned as a list of
-        atoms of shape (natoms,). 
+        atoms of shape (natoms,).
 
         Examples::
 
@@ -673,7 +674,7 @@ class Calculation(models.Model):
 
     def read_lattice_vectors(self):
         """
-        Reads and returns a numpy ndarray of lattice vectors for every ionic 
+        Reads and returns a numpy ndarray of lattice vectors for every ionic
         step of the calculation.
 
         Examples::
@@ -703,7 +704,7 @@ class Calculation(models.Model):
         """
         Reads and returns VASP-calculated projected charge for each atom. Returns the
         RAW charge, not NET charge.
-        
+
         Examples::
 
             >>> calc = Calculation.read('path_to_calculation')
@@ -788,8 +789,8 @@ class Calculation(models.Model):
 
     def read_stresses(self):
         """
-            Using vasprun.xml.gz to collect stresses.
-            In future, this function will be moved to read_output_from_vasprun()
+        Using vasprun.xml.gz to collect stresses.
+        In future, this function will be moved to read_output_from_vasprun()
         """
         try:
             stresses = []
@@ -1679,12 +1680,12 @@ class Calculation(models.Model):
 
         Arguments:
             source: can be another :mod:`~qmpy.Calculation` instance or a
-            string containing a path to a WAVECAR. If it is a path, it should 
-            be a absolute, i.e. begin with "/", and can either end with the 
+            string containing a path to a WAVECAR. If it is a path, it should
+            be a absolute, i.e. begin with "/", and can either end with the
             WAVECAR or simply point to the path that contains it. For
-            example, if you want to take the WAVECAR from a previous 
+            example, if you want to take the WAVECAR from a previous
             calculation you can do any of::
-            
+
             >>> c1 # old calculation
             >>> c2 # new calculation
             >>> c2.set_wavecar(c1)
@@ -1714,12 +1715,12 @@ class Calculation(models.Model):
 
         Arguments:
             source: can be another :mod:`~qmpy.Calculation` instance or a
-            string containing a path to a CHGCAR. If it is a path, it should 
-            be a absolute, i.e. begin with "/", and can either end with the 
+            string containing a path to a CHGCAR. If it is a path, it should
+            be a absolute, i.e. begin with "/", and can either end with the
             CHGCAR or simply point to the path that contains it. For
-            example, if you want to take the CHGCAR from a previous 
+            example, if you want to take the CHGCAR from a previous
             calculation you can do any of::
-            
+
             >>> c1 # old calculation
             >>> c2 # new calculation
             >>> c2.set_chgcar(c1)
@@ -1760,7 +1761,7 @@ class Calculation(models.Model):
     def formation_energy(self, reference="standard"):
         try:
             fe_set = self.formationenergy_set.filter(fit__name=reference)
-            if len(fe_set)==0:
+            if len(fe_set) == 0:
                 return self.get_formation(reference=reference).delta_e
             else:
                 return fe_set[0].delta_e
@@ -1814,7 +1815,7 @@ class Calculation(models.Model):
             input structure file.
 
         Keyword Arguments:
-            configuration: 
+            configuration:
                 String indicating the type of calculation to
                 perform. Options can be found with qmpy.VASP_SETTINGS.keys().
                 Create your own configuration options by adding a new file to
@@ -1824,9 +1825,9 @@ class Calculation(models.Model):
             settings:
                 Dictionary of VASP settings to be applied to the calculation.
                 Is applied after the settings which are provided by the
-                `configuration` choice. 
+                `configuration` choice.
 
-            path: 
+            path:
                 Location at which to perform the calculation. If the
                 calculation takes repeated iterations to finish successfully,
                 all steps will be nested in the `path` directory.
@@ -1836,13 +1837,13 @@ class Calculation(models.Model):
                 an entry to associate with the calculation.
 
             hubbard:
-                String indicating the hubbard correctionconvention. Options 
+                String indicating the hubbard correctionconvention. Options
                 found with qmpy.HUBBARDS.keys(), and can be added to or
                 altered by editing configuration/vasp_settings/hubbards.yml.
                 Default="wang".
 
             potentials:
-                String indicating the vasp potentials to use. Options can be 
+                String indicating the vasp potentials to use. Options can be
                 found with qmpy.POTENTIALS.keys(), and can be added to or
                 altered by editing configuration/vasp_settings/potentials/yml.
                 Default="vasp_rec".
@@ -1906,7 +1907,7 @@ class Calculation(models.Model):
 
         calc.set_potentials(vasp_settings.get("potentials", "vasp_rec"))
         calc.set_hubbards(vasp_settings.get("hubbards", hubbard))
-        #calc.set_magmoms(vasp_settings.get("magnetism", "ferro"))
+        # calc.set_magmoms(vasp_settings.get("magnetism", "ferro"))
 
         if "scale_encut" in vasp_settings:
             enmax = max(pot.enmax for pot in calc.potentials)
@@ -1927,7 +1928,7 @@ class Calculation(models.Model):
 
         # Read all outputs
         calc.read_stdout()
-        if not 'edddav' in calc.errors:
+        if not "edddav" in calc.errors:
             calc.read_outcar()
             calc.read_doscar()
 

--- a/qmpy/computing/resources.py
+++ b/qmpy/computing/resources.py
@@ -137,9 +137,9 @@ class Host(models.Model):
         | name: Primary key.
         | binaries: dict of label:path pairs for vasp binaries.
         | check_queue: Path to showq command
-        | checked_time: datetime object for the last time the queue was 
+        | checked_time: datetime object for the last time the queue was
         |   checked.
-        | hostname: Full host name. 
+        | hostname: Full host name.
         | ip_address: Full ip address.
         | nodes: Total number of nodes.
         | ppn: Number of processors per node.
@@ -372,7 +372,7 @@ class Host(models.Model):
         running = {}
         if not raw_data:
             return
-        elif type(raw_data)==bytes:
+        elif type(raw_data) == bytes:
             raw_data = raw_data.decode()
 
         ## < Mohan
@@ -432,7 +432,7 @@ class Host(models.Model):
 
     def deactivate(self):
         """
-        Prevent new jobs from being started on this system. 
+        Prevent new jobs from being started on this system.
         Remember to save() changes
         """
         self.state = -1
@@ -464,8 +464,8 @@ class Host(models.Model):
 
 
 class Account(models.Model):
-    """ 
-    Base class for a `User` account on a `Host`. 
+    """
+    Base class for a `User` account on a `Host`.
 
     Attributes:
         | host
@@ -552,7 +552,7 @@ class Account(models.Model):
 
         print("Great! Lets test it real quick...")
         out = self.execute("whoami")
-        if out.decode('utf-8') == "%s\n" % self.username:
+        if out.decode("utf-8") == "%s\n" % self.username:
             print("Awesome! It worked!")
         else:
             print("Something appears to be wrong, talk to Scott...")
@@ -582,7 +582,7 @@ class Account(models.Model):
         else:
             # < Mohan
             tmp = stdout.strip().split()[0]
-            if type(tmp)==bytes:
+            if type(tmp) == bytes:
                 tmp = tmp.decode()
             if "Moab" in tmp:
                 jid = int(tmp.split(".")[1])
@@ -790,7 +790,7 @@ class Allocation(models.Model):
 
 class Project(models.Model):
     """
-    Base class for a project within qmpy. 
+    Base class for a project within qmpy.
 
     Attributes:
         | allocations

--- a/qmpy/computing/resources.py
+++ b/qmpy/computing/resources.py
@@ -552,7 +552,7 @@ class Account(models.Model):
 
         print("Great! Lets test it real quick...")
         out = self.execute("whoami")
-        if out == "%s\n" % self.username:
+        if out.decode('utf-8') == "%s\n" % self.username:
             print("Awesome! It worked!")
         else:
             print("Something appears to be wrong, talk to Scott...")

--- a/qmpy/computing/scripts.py
+++ b/qmpy/computing/scripts.py
@@ -452,7 +452,7 @@ def static(entry, xc_func="PBE", **kwargs):
         calc.save()
         f = calc.get_formation()  # LW 16 Jan 2016: Need to rewrite this to have
         # separate hulls for LDA / PBE / ...
-        
+        f.save() 
         ps = PhaseSpace(list(calc.input.comp.keys()))
         ps.compute_stabilities(reevaluate=True, save=True)
     else:

--- a/qmpy/computing/scripts.py
+++ b/qmpy/computing/scripts.py
@@ -449,46 +449,11 @@ def static(entry, xc_func="PBE", **kwargs):
 
     # Save calculation [ LW 20Jan16: Only for PBE for now ]
     if calc.converged and xc_func.lower() == "pbe":
+        calc.save()
         f = calc.get_formation()  # LW 16 Jan 2016: Need to rewrite this to have
         # separate hulls for LDA / PBE / ...
-        calc.save()
-        f.calculation = calc
-        f.save()
         
         ps = PhaseSpace(list(calc.input.comp.keys()))
-        '''
-        for p in ps.phases:
-            if p in list(ps.phase_dict.values()):
-                ps.compute_stability(p)
-            else:
-                p2 = ps.phase_dict[p.name]
-                ps.compute_stability(p2)
-                base = max(0, p2.stability)
-                diff = p.energy - p2.energy
-                p.stability = base + diff
-
-            temp_c = Calculation.objects.get(formationenergy__id=p.id)
-            if temp_c.id == calc.id:
-                print("new calc stability")
-                f.stability = p.stability
-                f.save()
-            else:
-                try:
-                    fe = temp_c.get_formation()
-                except MultipleObjectsReturned:
-                    print(
-                        (
-                            "Calculation ",
-                            temp_c.id,
-                            " has more than one formationenergy",
-                        )
-                    )
-                    continue
-                if fe is None:
-                    continue
-                fe.stability = p.stability
-                fe.save()
-            '''
         ps.compute_stabilities(reevaluate=True, save=True)
     else:
         calc.write()

--- a/qmpy/computing/scripts.py
+++ b/qmpy/computing/scripts.py
@@ -131,7 +131,7 @@ def standard(entry, **kwargs):
 
 def check_spin(entry, xc_func="PBE"):
     """
-    Special case for Co-containing materials. Run calculation 
+    Special case for Co-containing materials. Run calculation
     at with Co in low and high spin state
 
     Arguments:
@@ -188,7 +188,7 @@ def relaxation(entry, xc_func="PBE", **kwargs):
     Arguments:
         entry:
             Entry, structure to be relaxed
-    
+
     Keyword Arguments:
         xc_func:
             String, name of XC function to use (Default='PBE'). Is used to
@@ -226,7 +226,12 @@ def relaxation(entry, xc_func="PBE", **kwargs):
         projects = entry.project_set.all()
         if "fast" in entry.keywords:
             calc = Calculation.setup(
-                in_struct, entry=entry, configuration=cnfg_name, path=path, settings={"kpar":4}, **kwargs
+                in_struct,
+                entry=entry,
+                configuration=cnfg_name,
+                path=path,
+                settings={"kpar": 4},
+                **kwargs,
             )
         else:
             calc = Calculation.setup(
@@ -261,12 +266,20 @@ def relaxation(entry, xc_func="PBE", **kwargs):
 
             if "fast" in entry.keywords:
                 calc = Calculation.setup(
-                    in_struct, entry=entry, configuration=cnfg_name, path=lowspin_dir,
-                    settings={"kpar":4}, **kwargs
+                    in_struct,
+                    entry=entry,
+                    configuration=cnfg_name,
+                    path=lowspin_dir,
+                    settings={"kpar": 4},
+                    **kwargs,
                 )
             else:
                 calc = Calculation.setup(
-                    in_struct, entry=entry, configuration=cnfg_name, path=lowspin_dir, **kwargs
+                    in_struct,
+                    entry=entry,
+                    configuration=cnfg_name,
+                    path=lowspin_dir,
+                    **kwargs,
                 )
 
             # Return atoms to the low-spin configuration
@@ -297,7 +310,7 @@ def relaxation_lda(entry, **kwargs):
     Start a LDA relaxation calculation
 
     Arguments:
-        entry: 
+        entry:
             Entry to be run
 
     Output:
@@ -309,12 +322,12 @@ def relaxation_lda(entry, **kwargs):
 
 def static(entry, xc_func="PBE", **kwargs):
     """
-    Start a final, accurate static calculation 
-    
+    Start a final, accurate static calculation
+
     Arguments:
         entry:
             Entry, structure to be relaxed
-    
+
     Keyword Arguments:
         xc_func:
             String, name of XC function to use (Default='PBE'). Is used to
@@ -334,11 +347,11 @@ def static(entry, xc_func="PBE", **kwargs):
     high_name = "Co_highspin_static"
     high_relax_name = "relaxation"
     if xc_func.lower() != "pbe":
-        cnfg_name += "_%s"%(xc_func.lower())
-        low_relax_name += "_%s"%(xc_func.lower())
-        high_relax_name += "_%s"%(xc_func.lower())
-        low_name += "_%s"%(xc_func.lower())
-        high_name += "_%s"%(xc_func.lower())
+        cnfg_name += "_%s" % (xc_func.lower())
+        low_relax_name += "_%s" % (xc_func.lower())
+        high_relax_name += "_%s" % (xc_func.lower())
+        low_name += "_%s" % (xc_func.lower())
+        high_name += "_%s" % (xc_func.lower())
 
     # Get the calculation directory
     calc_dir = os.path.join(entry.path, cnfg_name)
@@ -346,13 +359,13 @@ def static(entry, xc_func="PBE", **kwargs):
     # If static calculation has converged, return that calculation
     if entry.calculations.get(cnfg_name, Calculation()).converged:
         return entry.calculations[cnfg_name]
-           
+
     # Get the relaxation calculation
     calc = relaxation(entry, xc_func=xc_func, **kwargs)
 
     # Special Case: Check whether relaxation is low-spin
     if hasattr(calc, "Co_lowspin"):
-        use_lowspin = ( calc.Co_lowspin is True )
+        use_lowspin = calc.Co_lowspin is True
         calc.add_Co_spin("Co_lowspin")
     else:
         use_lowspin = False
@@ -364,56 +377,68 @@ def static(entry, xc_func="PBE", **kwargs):
 
     # Special case: also perform the static for the higher energy spin configuration
     if "Co" in entry.comp:
-                                                                                 
-        # If the lower energy relaxation was high spin, perform now the low spin 
+
+        # If the lower energy relaxation was high spin, perform now the low spin
         if not use_lowspin:
-            
+
             # Update / start the low spin calculation
-            if not entry.calculations.get(low_name, Calculation()).converged and entry.calculations.get(low_relax_name, Calculation()).converged:
-            
+            if (
+                not entry.calculations.get(low_name, Calculation()).converged
+                and entry.calculations.get(low_relax_name, Calculation()).converged
+            ):
+
                 # Get the low_spin calculation directory
                 lowspin_dir = os.path.join(entry.path, low_name)
-            
+
                 # Get input structure
                 input_struct = entry.calculations[low_relax_name].output
-            
-                calc = Calculation.setup(input_struct,  entry=entry,
-                                                 configuration=cnfg_name,
-                                                 path=lowspin_dir,
-                                                 **kwargs)
-            
+
+                calc = Calculation.setup(
+                    input_struct,
+                    entry=entry,
+                    configuration=cnfg_name,
+                    path=lowspin_dir,
+                    **kwargs,
+                )
+
                 # Return atoms to the low-spin configuration
                 for atom in calc.input:
                     if atom.element.symbol == "Co":
                         atom.magmom = 0.01
-            
+
                 entry.calculations[low_name] = calc
                 calc.add_Co_spin("Co_lowspin")
 
                 if not calc.converged:
                     calc.write()
-                                                                                
+
         else:
-            
+
             # Update / start the high spin calculation
-            if not entry.calculations.get(high_name, Calculation()).converged and entry.calculations.get(high_relax_name, Calculation()).converged:
-            
+            if (
+                not entry.calculations.get(high_name, Calculation()).converged
+                and entry.calculations.get(high_relax_name, Calculation()).converged
+            ):
+
                 # Get the high_spin calculation directory
                 highspin_dir = os.path.join(entry.path, high_name)
-            
+
                 # Get input structure
                 input_struct = entry.calculations[high_relax_name].output
-            
-                calc = Calculation.setup(input_struct,  entry=entry,
-                                                 configuration=cnfg_name,
-                                                 path=highspin_dir,
-                                                 **kwargs)
-            
+
+                calc = Calculation.setup(
+                    input_struct,
+                    entry=entry,
+                    configuration=cnfg_name,
+                    path=highspin_dir,
+                    **kwargs,
+                )
+
                 # Return atoms to the high-spin configuration
                 for atom in calc.input:
                     if atom.element.symbol == "Co":
                         atom.magmom = 5
-            
+
                 entry.calculations[high_name] = calc
                 calc.add_Co_spin("Co_highspin")
 
@@ -429,13 +454,22 @@ def static(entry, xc_func="PBE", **kwargs):
     # Set up calculation
     if "fast" in entry.keywords:
         calc = Calculation.setup(
-            in_struct, entry=entry, configuration=cnfg_name, path=calc_dir, chgcar=chgcar_path,
-            settings={"kpar":4}, **kwargs
+            in_struct,
+            entry=entry,
+            configuration=cnfg_name,
+            path=calc_dir,
+            chgcar=chgcar_path,
+            settings={"kpar": 4},
+            **kwargs,
         )
     else:
         calc = Calculation.setup(
-            in_struct, entry=entry, configuration=cnfg_name, path=calc_dir, chgcar=chgcar_path,
-            **kwargs
+            in_struct,
+            entry=entry,
+            configuration=cnfg_name,
+            path=calc_dir,
+            chgcar=chgcar_path,
+            **kwargs,
         )
 
     # Special Case: Set Co to low-spin configuration
@@ -452,7 +486,7 @@ def static(entry, xc_func="PBE", **kwargs):
         calc.save()
         f = calc.get_formation()  # LW 16 Jan 2016: Need to rewrite this to have
         # separate hulls for LDA / PBE / ...
-        f.save() 
+        f.save()
         ps = PhaseSpace(list(calc.input.comp.keys()))
         ps.compute_stabilities(reevaluate=True, save=True)
     else:
@@ -466,9 +500,9 @@ def static_lda(entry, **kwargs):
 
     Input:
         entry - Entry, OQMD entry to be computed
-    
+
     Output:
-        Calculation, result 
+        Calculation, result
     """
 
     return static(entry, xc_func="LDA", **kwargs)

--- a/qmpy/materials/atom.py
+++ b/qmpy/materials/atom.py
@@ -41,7 +41,7 @@ class Atom(models.Model):
     Relationships:
         | :mod:`~qmpy.Structure` via structure
         | :mod:`~qmpy.Element` via element
-        | :mod:`~qmpy.Site` via site 
+        | :mod:`~qmpy.Site` via site
         | :mod:`~qmpy.WyckoffSite` via wyckoff
 
     Attributes:
@@ -106,7 +106,7 @@ class Atom(models.Model):
     def __eq__(self, other):
         if self.element_id != other.element_id:
             return False
-        return norm([self.x-other.x, self.y-other.y, self.z-other.z])<1e-4
+        return norm([self.x - other.x, self.y - other.y, self.z - other.z]) < 1e-4
 
     def __lt__(self, other):
         comp_arr = [
@@ -181,7 +181,7 @@ class Atom(models.Model):
     @property
     def index(self):
         """
-        None if not in a :mod:`~qmpy.Structure`, otherwise the index of the atom 
+        None if not in a :mod:`~qmpy.Structure`, otherwise the index of the atom
         in the structure.
         """
         if not self.structure:
@@ -191,26 +191,26 @@ class Atom(models.Model):
     @classmethod
     def create(cls, element, coord, **kwargs):
         """
-        Creates a new Atom object. 
+        Creates a new Atom object.
 
         Arguments:
             element (str or Element): Specifies the element of the Atom.
             coord (iterable of floats): Specifies the coordinate of the Atom.
 
         Keyword Arguments:
-            forces: 
+            forces:
                 Specifies the forces on the atom.
-            magmom: 
+            magmom:
                 The magnitude of the magnetic moment on the atom.
-            charge: 
+            charge:
                 The charge on the Atom.
-            volume: 
+            volume:
                 The atomic volume of the atom (Angstroms^3).
 
         Examples::
 
             >>> Atom.create('Fe', [0,0,0])
-            >>> Atom.create('Ni', [0.5, 0.5, 0.5], ox=2, magmom=5, 
+            >>> Atom.create('Ni', [0.5, 0.5, 0.5], ox=2, magmom=5,
             >>>                                 forces=[0.2, 0.2, 0.2],
             >>>                                 volume=101, charge=1.8,
             >>>                                 occupancy=1)
@@ -249,7 +249,7 @@ class Atom(models.Model):
             <Atom: Fe - 0.000, 0.000, 0.000>
             >>> a.id
             None
-        
+
         """
         atom = Atom()
         keys = [
@@ -318,9 +318,9 @@ class Atom(models.Model):
 
 class Site(models.Model):
     """
-    A lattice site. 
+    A lattice site.
 
-    A site can be occupied by one Atom, many Atoms or no Atoms. 
+    A site can be occupied by one Atom, many Atoms or no Atoms.
 
     Relationships:
         | :mod:`~qmpy.Structure` via structure
@@ -352,7 +352,7 @@ class Site(models.Model):
         db_table = "sites"
 
     def __hash__(self):
-         return hash(self._get_pk_val())
+        return hash(self._get_pk_val())
 
     def __eq__(self, other):
         return (self.x, self.y, self.z) == (other.x, other.y, other.z)
@@ -495,7 +495,7 @@ class Site(models.Model):
           atoms (iterable of `Atom`): List of Atoms to occupy the Site.
 
         Keyword Arguments:
-          tol (float): Atoms must be within `tol` of each other to be assigned 
+          tol (float): Atoms must be within `tol` of each other to be assigned
           to the same Site. Defaults to 1e-4.
 
         Examples::
@@ -525,7 +525,7 @@ class Site(models.Model):
           The Site is created without any Atoms occupying it.
 
         Arguments:
-          coord (length 3 iterable): Assigns the x, y, and z coordinates of 
+          coord (length 3 iterable): Assigns the x, y, and z coordinates of
             the Site.
 
         Keyword Arguments:
@@ -572,8 +572,8 @@ class Site(models.Model):
         Composition dictionary of the Site.
 
         Returns:
-          dict: of (element, occupancy) pairs. 
-        
+          dict: of (element, occupancy) pairs.
+
         Examples::
 
             >>> a1 = Atom('Fe', [0,0,0], occupancy=0.2)
@@ -602,8 +602,8 @@ class Site(models.Model):
         Composition dictionary of the Site.
 
         Returns:
-          dict: of (species, occupancy) pairs. 
-        
+          dict: of (species, occupancy) pairs.
+
         Examples::
 
             >>> a1 = Atom('Fe', [0,0,0], occupancy=0.2)
@@ -620,7 +620,7 @@ class Site(models.Model):
 
     def add_atom(self, atom, tol=None):
         """
-        Adds Atom to `Site.atoms`. 
+        Adds Atom to `Site.atoms`.
 
         Notes:
           If the Site being assigned to doens't have a coordinate, it is assigned
@@ -630,12 +630,12 @@ class Site(models.Model):
           atom (Atom): Atom to add to the structure.
 
         Keyword Arguments:
-          tol (float): Distance between `atom` and the Site for the Atom to be 
-            assigned to the Site. Raises a SiteError if the distance is 
-            greater than `tol`. 
+          tol (float): Distance between `atom` and the Site for the Atom to be
+            assigned to the Site. Raises a SiteError if the distance is
+            greater than `tol`.
 
         Raises:
-          SiteError: If `atom` is more than `tol` from the Site. 
+          SiteError: If `atom` is more than `tol` from the Site.
 
         Examples::
 
@@ -660,7 +660,7 @@ class Site(models.Model):
     @property
     def magmom(self):
         """
-        Calculates the composition weighted average magnetic moment of the atoms 
+        Calculates the composition weighted average magnetic moment of the atoms
         on the Site.
 
         Returns:
@@ -678,7 +678,7 @@ class Site(models.Model):
     @property
     def ox(self):
         """
-        Calculates the composition weighted average oxidation state of the atoms 
+        Calculates the composition weighted average oxidation state of the atoms
         on the Site.
 
         Returns:

--- a/qmpy/materials/atom.py
+++ b/qmpy/materials/atom.py
@@ -106,7 +106,7 @@ class Atom(models.Model):
     def __eq__(self, other):
         if self.element_id != other.element_id:
             return False
-        return (self.x, self.y, self.z) == (other.x, other.y, other.z)
+        return norm([self.x-other.x, self.y-other.y, self.z-other.z])<1e-4
 
     def __lt__(self, other):
         comp_arr = [

--- a/qmpy/materials/formation_energy.py
+++ b/qmpy/materials/formation_energy.py
@@ -155,7 +155,7 @@ class FormationEnergy(models.Model):
     )
     entry = models.ForeignKey("Entry", null=True, blank=True, on_delete=models.CASCADE)
     calculation = models.ForeignKey(
-        "Calculation", null=True, blank=True, on_delete=models.SET_NULL
+        "Calculation", null=True, blank=True, on_delete=models.CASCADE
     )
     description = models.CharField(max_length=20, null=True, blank=True)
     fit = models.ForeignKey("Fit", null=True, on_delete=models.PROTECT)

--- a/qmpy/materials/formation_energy.py
+++ b/qmpy/materials/formation_energy.py
@@ -207,14 +207,14 @@ Formation = FormationEnergy
 
 class Fit(models.Model):
     """
-    The core model for a reference energy fitting scheme. 
-    
-    The Fit model links to the experimental data (ExptFormationEnergy objects) 
-    that informed the fit, as well as the DFT calculations (Calculation objects) 
-    that were matched to each experimental formation energy. Once the fit is 
-    completed, it also stores a list of chemical potentials both as a 
-    relationship to ReferenceEnergy and HubbardCorrection objects. 
-    These correction energies can also be accessed by dictionaries at 
+    The core model for a reference energy fitting scheme.
+
+    The Fit model links to the experimental data (ExptFormationEnergy objects)
+    that informed the fit, as well as the DFT calculations (Calculation objects)
+    that were matched to each experimental formation energy. Once the fit is
+    completed, it also stores a list of chemical potentials both as a
+    relationship to ReferenceEnergy and HubbardCorrection objects.
+    These correction energies can also be accessed by dictionaries at
     Fit.mus and Fit.hubbard_mus.
 
     Relationships:
@@ -226,7 +226,7 @@ class Fit(models.Model):
 
     Attributes:
         | name: Name for the fitting
-    
+
     Examples::
 
         >>> f = Fit.get('standard')

--- a/qmpy/materials/structure.py
+++ b/qmpy/materials/structure.py
@@ -264,13 +264,13 @@ class Structure(models.Model, object):
         if not self.spacegroup:
             self.symmetrize()
         super(Structure, self).save(*args, **kwargs)
-        
+
     _atoms = None
 
     @property
     def atoms(self):
         """
-        List of ``Atoms`` in the structure. 
+        List of ``Atoms`` in the structure.
         """
         if self._atoms is None:
             if not self.id:
@@ -696,11 +696,11 @@ class Structure(models.Model, object):
 
         5. If needed check that the primitive cell volumes are the same
 
-        6. Convert both primitive cells to reduced form There is one issue here - 
-        the reduce cell could be type I (all angles acute) or type II (all angles 
-        obtuse) and a slight difference in the initial cells could cause two 
-        structures to reduce to different types. So at this step, if the angles 
-        are not correct, the second cell is transformed as 
+        6. Convert both primitive cells to reduced form There is one issue here -
+        the reduce cell could be type I (all angles acute) or type II (all angles
+        obtuse) and a slight difference in the initial cells could cause two
+        structures to reduce to different types. So at this step, if the angles
+        are not correct, the second cell is transformed as
         [[-1, 0, 0], [0, -1, 0], [0, 0, 1]].
 
         7. Check that the cell internal angles are the same in both reduced
@@ -911,20 +911,20 @@ class Structure(models.Model, object):
             demonstrate that for any non-cubic cell, the normal method of
             calculating the distance by wrapping the vector in fractional
             coordinates to the range (-0.5, 0.5) fails for cases near (0.5,0.5)
-            in Type I cells and near (0.5, -0.5) for Type II. 
+            in Type I cells and near (0.5, -0.5) for Type II.
 
             To get the correct distance, the vector must be wrapped into the
-            Wigner-Seitz cell. 
+            Wigner-Seitz cell.
 
         Arguments:
             atom1, atom2: (:mod:`~qmpy.Atom`, :mod:`~qmpy.Site`, int).
 
         Keyword Arguments:
-            limit: 
+            limit:
                 If a limit is provided, returns None if the distance is
                 greater than the limit.
 
-            wrap_self: 
+            wrap_self:
                 If True, the distance from an atom to itself is 0, otherwise it
                 is the distance to the shortest periodic image of itself.
 
@@ -1300,13 +1300,13 @@ class Structure(models.Model, object):
         """Uses spglib to convert to the conventional cell.
 
         Keyword Arguments:
-            in_place: 
+            in_place:
                 If True, changes the current structure. If false returns
                 a new one
 
-            tol: 
+            tol:
                 Symmetry precision for symmetry analysis
-        
+
         Examples::
 
             >>> s = io.read(INSTALL_PATH+'io/files/POSCAR_FCC_prim')
@@ -1328,13 +1328,13 @@ class Structure(models.Model, object):
         """Uses spglib to convert to the primitive cell.
 
         Keyword Arguments:
-            in_place: 
+            in_place:
                 If True, changes the current structure. If false returns
                 a new one
 
-            tol: 
+            tol:
                 Symmetry precision for symmetry analysis
-        
+
         Examples::
 
             >>> s = io.read(INSTALL_PATH+'io/files/POSCAR_FCC')
@@ -1472,8 +1472,8 @@ class Structure(models.Model, object):
 
         Keyword Arguments:
             elements:
-                If `elements` is supplied, get_lattice_network will return the 
-                lattice of those elements only. 
+                If `elements` is supplied, get_lattice_network will return the
+                lattice of those elements only.
 
             supercell:
                 Accepts any valid input to Structure.transform to construct a
@@ -1487,7 +1487,7 @@ class Structure(models.Model, object):
             neighbors.
 
         Examples::
-            
+
             >>> s = io.read(INSTALL_PATH+'/io/files/fe3o4.cif')
             >>> sl = s.get_lattice_network(elements=['Fe'])
             >>> sl.set_fraction(0.33333)
@@ -1573,7 +1573,7 @@ class Structure(models.Model, object):
         identified by index.
 
         Keyword Arguments:
-            in_place: 
+            in_place:
                 If False, return a new Structure with the transformation applied.
                 defaults to True.
 
@@ -1608,7 +1608,7 @@ class Structure(models.Model, object):
 
     def translate(self, cv, cartesian=True, in_place=True):
         """
-        Shifts the contents of the structure by a vector. 
+        Shifts the contents of the structure by a vector.
 
         Optional keyword arguments:
             *cartesian*     : If True, translation vector is taken to be
@@ -1737,7 +1737,7 @@ class Structure(models.Model, object):
         """
         Apply lattice transform to the structure. Accepts transformations of
         shape (3,) and (3,3).
-        
+
         Optional keyword arguments:
             *in_place*      : If False, return a new Structure with the
                                 transformation applied.
@@ -1829,18 +1829,18 @@ class Structure(models.Model, object):
     def substitute(
         self, replace, rescale=True, rescale_method="relative", in_place=False, **kwargs
     ):
-        """Replace atoms, as specified in a dict of pairs. 
+        """Replace atoms, as specified in a dict of pairs.
 
         Keyword Arguments:
-            rescale: 
-                rescale the volume of the final structure based on the per 
+            rescale:
+                rescale the volume of the final structure based on the per
                 atom volume of the new composition.
 
             rescale_method:
-                How to rescale the 
+                How to rescale the
 
-            in_place: 
-                change the species of the current Structure or return a new 
+            in_place:
+                change the species of the current Structure or return a new
                 one.
 
         Examples::
@@ -1881,9 +1881,9 @@ class Structure(models.Model, object):
         Identify atoms that are close to high symmetry sites (within `tol` and
         shift them onto them.
 
-        Note: 
+        Note:
             "symprec" doesn't appear to do anything with spglib, so I am
-            unable to get "loose" symmetry operations. Without which, this 
+            unable to get "loose" symmetry operations. Without which, this
             doesn't work.
 
         Examples::
@@ -1922,16 +1922,16 @@ class Structure(models.Model, object):
         Acta. Cryst. (2003) A60, 1
 
         Optional keyword arguments:
-            *tol* : 
-                eps_rel in Acta. Cryst. 2003 above. Similar to 
+            *tol* :
+                eps_rel in Acta. Cryst. 2003 above. Similar to
                 tolerance for floating point comparisons. Defaults to 1e-5.
-            *limit* : 
-                maximum number of loops through the algorithm. Defaults to 
-                1000. 
-            *in_place* : 
-                Change the Structure or return a new one. If True, the 
+            *limit* :
+                maximum number of loops through the algorithm. Defaults to
+                1000.
+            *in_place* :
+                Change the Structure or return a new one. If True, the
                 transformation matrix is returned. If False, a tuple of
-                (Structure, transformation_matrix) is returned. 
+                (Structure, transformation_matrix) is returned.
 
         Examples::
 
@@ -2063,8 +2063,10 @@ class Structure(models.Model, object):
                 continue
             break
 
-        if (trans == np.array([[-1.,  0.,  0.], [ 0., -1.,  0.], [ 0.,  0., -1.]])).all():
-            trans = np.array([[1.,  0.,  0.], [ 0., 1.,  0.], [ 0.,  0., 1.]])
+        if (
+            trans == np.array([[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]])
+        ).all():
+            trans = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
         # temporarily stored transformations
         self._original_cell = self.cell.copy()
@@ -2125,7 +2127,7 @@ class Structure(models.Model, object):
             in_place: apply change to current structure, or return a new one.
 
         Examples::
-            
+
             >>> s = io.read(INSTALL_PATH+'/io/files/POSCAR_FCC')
             >>> s.create_vacuum(2, 5)
         """
@@ -2147,7 +2149,7 @@ class Structure(models.Model, object):
         If a site is not fully occupied, but has only one atom type on it, it
         will be filled the rest of the way.
         If a site has two or more atom types on it, the higher fraction element
-        will fill the site. 
+        will fill the site.
 
         Keyword Arguments:
             in_place: If False returns a new :mod:`~qmpy.Structure`, otherwise
@@ -2156,7 +2158,7 @@ class Structure(models.Model, object):
             tol: maximum defect concentration.
 
         Examples::
-            
+
             >>> s = io.read(INSTALL_PATH+'/io/files/partial_vac.cif')
             >>> s
             <Structure: Mn3.356Si4O16>
@@ -2229,7 +2231,7 @@ class Structure(models.Model, object):
 
 class Prototype(models.Model):
     """
-    Base class for a prototype structure. 
+    Base class for a prototype structure.
 
     Relationships:
         | :mod:`~qmpy.Composition` via composition_set

--- a/qmpy/materials/structure.py
+++ b/qmpy/materials/structure.py
@@ -251,12 +251,14 @@ class Structure(models.Model, object):
             for s in self.sites:
                 if not s.id:
                     s.save()
-                self.site_set.add(s)
+                if not s in self.site_set.all():
+                    self.site_set.add(s)
         if not self._atoms is None:
             for a in self.atoms:
                 if not a.id:
                     a.save()
-                self.atom_set.add(a)
+                if not a in self.atom_set.all():
+                    self.atom_set.add(a)
         super(Structure, self).save(*args, **kwargs)
 
         if not self.spacegroup:


### PR DESCRIPTION
This very long explanation for the bugfix is required here because the bug addressed here have been under the debugging stage for the past 1.5 years. Some of the unusual scenarios mentioned here can be useful for future bugfixes.

## Fix for issues with 
1. duplicate atoms being added to the `qmpy.calculation.input` and `qmpy.calculation.ouput` structures, and 
2. calculation of `stability` for new calculations
------------------------------

### Issue 1:
Several structures in OQMD had all or few of the atoms included twice in the `structure.atoms`.

### Underlying Problem:
1. Adding atoms to `Structure.atom` through Django related object `atom_set.add()` without rechecking for duplicates in the structure posed the potential for errors. This was called while saving the `Structure`.
It may not have been an issue before with Django 1.6 but behavioral changes for Django.Model in Django 1.8 and 2.2 made it important. In addition to it, the bug wasn't captured while printing len(calculation.input.atoms) during the calculations because of the lazy execution nature of atom_site.add() function. Because, as mentioned before, it is a default related object made with QuerySets and associated functions ([See here](https://docs.djangoproject.com/en/2.2/ref/models/relations/))

2. In addition to that, the duplicated atoms had slight differences in coordinate values at their least significant decimal places (~ 6th to 15th decimal places for the situation in consideration here). So the `Atom.__eq__` function determined them to be different.

### Solution:
1. Added a duplicate check before `atom_set.add()` and `site.set.add()`
2. Modified `Atom.__eq__` function to ignore very small differences on coords (if norm of differences < 1e-4)

------------------------------
### Issue 2:
The stability value was computed for each converged static calculation but not saved in the DB.

### Underlying Problem:
The stability value was first stored in the DB while calling `ps.compute_stabilities`. But they were overwritten later by `calculation.formation` object's stability value created inside `calculation.get_formation`. These overwriting calls came predominantly while saving the `calculation` object, which calls for `self.formation.save()`
The difficulties in debugging during the past 1.5 years happened mainly because, the errors in the static calculation scripts in `scripts.py` did not print any exceptions even while encountering errors. It must've been due to the suppression of error messages on `try-except` with no error logging/printing actions. 

### Solution:
1. `Calculation.formation` is no longer a class variable. Instead, it's a property whose values can be altered only by calling the related `FormationEnergy` object explicitly. This does not change the DB schema as the `calculation.formation` was not written previously as a column within the `Calculation` table anyway. 
2. `FormationEnergy` object(s) linked to `Calculation` is(are) not saved once again when the `Calculation.save` method is called. It doesn't have to be as the `FormationEnergy` objects are saved while calling `ps.compute_stabilites(save=True)`

-------------------------------

### Other commits
Fix to an issue with parsing output from ssh queries in Python3