### PR TITLE
Add radioactive elements to data/elements/groups.yaml

### DIFF
--- a/qmpy/data/elements/groups.yml
+++ b/qmpy/data/elements/groups.yml
@@ -73,5 +73,4 @@ rareearth: [Ce, Dy, Er, Eu, Gd, Ho, La, Lu, Nd, Pm, Pr, Sc, Sm, Tb, Tm, Y, Yb]
 simple-metals: [Ag, Al, Au, Ba, Be, Bi, Ca, Cd, Co, Cr, Cs, Cu, Fe, Ga, Hf, Hg, In,
   Ir, K, La, Li, Mg, Mn, Mo, Na, Nb, Ni, Os, Pb, Pd, Pt, Rb, Re, Rh, Ru, Sc, Sn, Sr,
   Ta, Tc, Ti, Tl, V, W, Y, Zn, Zr]
-radioactive: [Tc, Pm, Po, At, Rn, Fr, Ra, Ac, Th, Pa, U, Np, Pu, Am, Cm, Bk, Cf, Es,
-  Fm, Md, 'No', Lr, Rf, Db, Sg, Bh, Hs, Mt, Ds, Rg, Cn]
+radioactive: [Tc, Pm, Ac, Th, Pa, U, Np, Pu]

--- a/qmpy/data/elements/groups.yml
+++ b/qmpy/data/elements/groups.yml
@@ -73,3 +73,5 @@ rareearth: [Ce, Dy, Er, Eu, Gd, Ho, La, Lu, Nd, Pm, Pr, Sc, Sm, Tb, Tm, Y, Yb]
 simple-metals: [Ag, Al, Au, Ba, Be, Bi, Ca, Cd, Co, Cr, Cs, Cu, Fe, Ga, Hf, Hg, In,
   Ir, K, La, Li, Mg, Mn, Mo, Na, Nb, Ni, Os, Pb, Pd, Pt, Rb, Re, Rh, Ru, Sc, Sn, Sr,
   Ta, Tc, Ti, Tl, V, W, Y, Zn, Zr]
+radioactive: [Tc, Pm, Po, At, Rn, Fr, Ra, Ac, Th, Pa, U, Np, Pu, Am, Cm, Bk, Cf, Es,
+  Fm, Md, 'No', Lr, Rf, Db, Sg, Bh, Hs, Mt, Ds, Rg, Cn]


### PR DESCRIPTION
I have updated groups.yaml to make it possible to filter out radioactive elements.
Note: Element "No" needs to be in quotes for the yml to parse properly.