### PR TITLE
Fixes for OPTIMADE structures and info

### DIFF
--- a/qmpy/utils/oqmd_optimade/grammar/optimade_info.json
+++ b/qmpy/utils/oqmd_optimade/grammar/optimade_info.json
@@ -5,7 +5,11 @@
       "representation": "/info"
     },
     "more_data_available": false,
-    "schema": "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+    "schema": "https://schemas.optimade.org/openapi/v1.0/optimade_index.json",
+    "provider": {
+        "name": "Open Quantum Materials Database",
+        "prefix": "oqmd"
+    }
   },
   "data": {
     "type": "info",

--- a/qmpy/utils/oqmd_optimade/grammar/optimade_info_structures.json
+++ b/qmpy/utils/oqmd_optimade/grammar/optimade_info_structures.json
@@ -5,7 +5,11 @@
        "representation": "/info/structures"
      },
      "more_data_available": false,
-     "schema": "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+     "schema": "https://schemas.optimade.org/openapi/v1.0/optimade_index.json",
+     "provider": {
+         "name": "Open Quantum Materials Database",
+         "prefix": "oqmd"
+     }
   },
   "data": {
     "description": "a structures entry",

--- a/qmpy/web/serializers/optimade.py
+++ b/qmpy/web/serializers/optimade.py
@@ -77,7 +77,7 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
     def get_elements(self, formationenergy):
         elst = formationenergy.composition.element_list.split("_")
         elst.pop()
-        return ",".join(elst)
+        return elst
 
     def get_lattice_vectors(self, formationenergy):
         try:

--- a/qmpy/web/serializers/optimade.py
+++ b/qmpy/web/serializers/optimade.py
@@ -60,7 +60,13 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
 
     # Optimade recommended structure-related properties
     def get_chemical_formula_reduced(self, formationenergy):
-        return formationenergy.composition.formula.replace(" ", "")
+        # Remove spaces and remove "1" from composition, e.g. O2 Si1 -> O2Si
+        formula = formationenergy.composition.formula.split()
+        for ind, species in enumerate(formula):
+            if species[-1] == "1" and species[-2].isalpha():
+                formula[ind] = species[:-1]
+
+        return "".join(formula)
 
     def get_chemical_formula_anonymous(self, formationenergy):
         return formationenergy.composition.generic

--- a/qmpy/web/serializers/optimade.py
+++ b/qmpy/web/serializers/optimade.py
@@ -135,7 +135,8 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
         return ""
 
     def get_species(self, _):
-        return []
+        species_set = set(s.label for s in formationenergy.calculation.output.sites)
+        return {s: {"name": s, "chemical_symbols": [s], "concentration": 1} for s in species_set}
 
     # OQMD specific data
     def get__oqmd_icsd_id(self, formationenergy):

--- a/qmpy/web/serializers/optimade.py
+++ b/qmpy/web/serializers/optimade.py
@@ -56,7 +56,7 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
         return "structures"
 
     def get_last_modified(self, _):
-        return ""
+        return None
 
     # Optimade recommended structure-related properties
     def get_chemical_formula_reduced(self, formationenergy):
@@ -89,7 +89,7 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
                 [strct.z1, strct.z2, strct.z3],
             ]
         except:
-            return []
+            return None
 
     def get_nsites(self, formationenergy):
         return formationenergy.entry.natoms
@@ -100,7 +100,7 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
             sites = [s.label for s in strct.sites]
             return sites
         except:
-            return []
+            return None
 
     def get_cartesian_site_positions(self, formationenergy):
         try:
@@ -108,7 +108,7 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
             sites = [s.atoms[0].cart_coord.round(6).tolist() for s in strct.sites]
             return sites
         except:
-            return []
+            return None
 
     def get__oqmd_direct_site_positions(self, formationenergy):
         try:
@@ -126,7 +126,7 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
         return 3
 
     def get_elements_ratios(self, _):
-        return []
+        return None
 
     def get_structure_features(self, _):
         return []


### PR DESCRIPTION
A few fixes mentioned in #128, namely:

- [x] Fix `chemical_formula_reduced` (strip "1" proportions like O2Si1)
- [x] Make `elements` a list not a string
- [x] Add a default response for `species`
- [x] Return `null` when value is missing
- [x] Add provider prefix to meta response for `/info` and `/info/structures`. 

This is probably as far as I can take it @tachyontraveler, without setting up the API and writing tests myself.