### PR TITLE
OPTIMADE-related fix (chemical_formula_anonymous vs generic)

### DIFF
--- a/qmpy/utils/oqmd_optimade/optimade_spec_data.py
+++ b/qmpy/utils/oqmd_optimade/optimade_spec_data.py
@@ -5,6 +5,7 @@ import os
 def get_optimade_data(label):
     """
     Function providing data for all optimade endpoints, except the data-endpoint
+
     Currently served end-points are:
         1. Info endpoint : Provides general information about the API implementation
         2. Info/Structures endpoint : Provides information specific to the structures-data

--- a/qmpy/utils/strings.py
+++ b/qmpy/utils/strings.py
@@ -420,3 +420,13 @@ def read_fortran_array(string, expected_cols=None):
         if len(arr) != expected_cols:
             raise ValueError
     return arr
+
+
+def reverse_generic_order(formula):
+    # Split the formula to elements and amounts, reverse the amounts, recreate the formula
+    gen_comp = re_formula.findall(formula)
+    elts = [item[0] for item in gen_comp]
+    amts = [item[1] for item in gen_comp]
+    amts.reverse()
+    gen_comp = list(zip(elts, amts))
+    return "".join("{elt}{amt}".format(elt=elt, amt=amt) for elt, amt in gen_comp)

--- a/qmpy/web/serializers/optimade.py
+++ b/qmpy/web/serializers/optimade.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from qmpy.materials.formation_energy import FormationEnergy
 from drf_queryfields import QueryFieldsMixin
+from qmpy.utils import reverse_generic_order
 
 
 class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer):
@@ -71,7 +72,10 @@ class OptimadeStructureSerializer(QueryFieldsMixin, serializers.ModelSerializer)
         return "".join(formula)
 
     def get_chemical_formula_anonymous(self, formationenergy):
-        return formationenergy.composition.generic
+        # The generic composition appears in the opposite order between OPTIMADE and OQMD
+        # e.g., ABCD4 vs A4BCD, so it needs to be reversed
+        formula = formationenergy.composition.generic
+        return reverse_generic_order(formula)
 
     def get_nelements(self, formationenergy):
         return formationenergy.composition.ntypes


### PR DESCRIPTION
OQMD and OPTIMADE have different ordering of anonymous/generic elements in the generic formula. This caused disagreements with the OPTIMADE response format for that parameter. 

More info: [Related Issue](https://github.com/wolverton-research-group/qmpy/issues/128#issuecomment-996289132)


This PR also includes better error reporting from REST query parsing. A 501 error is added to highlight `Not Implemented` errors.